### PR TITLE
Change dutch translation "Rapen" to "Knollen"

### DIFF
--- a/res/lang/nl.json
+++ b/res/lang/nl.json
@@ -2,7 +2,7 @@
     "app_name":           "Turnips",
     "version":            "versie",
 
-    "turnips":            "Rapen",
+    "turnips":            "Knollen",
     "visitors":           "Bezoekers",
     "weather":            "Weer",
     "language":           "Taal",


### PR DESCRIPTION
The translation used in the Dutch version of Animal crossing is "Knollen".
Just a small detail :))