### PR TITLE
Update for v1.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 TOPDIR           ?=   $(CURDIR)
 
-VERSION           =   1.6.10
+VERSION           =   1.6.11
 COMMIT            =   $(shell git rev-parse --short HEAD)
 
 # -----------------------------------------------

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -41,6 +41,7 @@ enum class Version: std::size_t {
     V180,
     V190,
     V1110,
+    V1111,
     Unknown,
     Total = Unknown,
 };
@@ -125,6 +126,7 @@ class VersionParser {
             VersionInfo{ 0x78001, 0x78001, 2, 0, 2, 17 }, // 1.8.0
             VersionInfo{ 0x7c001, 0x7c006, 2, 0, 2, 18 }, // 1.9.0
             VersionInfo{ 0x7d001, 0x7d004, 2, 0, 2, 19 }, // 1.10.0
+            VersionInfo{ 0x7e001, 0x7e001, 2, 0, 2, 20 }, // 1.11.0
         };
 
         static_assert(versions.size() == static_cast<std::size_t>(Version::Total));
@@ -168,6 +170,7 @@ class TurnipParser {
             0x41b63cul,                                                 // 1.8.0
             0x43ec6cul,                                                 // 1.9.0
             0x43ec7cul,                                                 // 1.10.0
+	    0x43ec7cul,                                                 // 1.11.0
         };
 
         constexpr static std::array turnip_patterns = {
@@ -218,6 +221,7 @@ class VisitorParser {
             0x41f0b4ul,                                                 // 1.8.0
             0x4426e4ul,                                                 // 1.9.0
             0x4426f4ul,                                                 // 1.10.0
+	    0x4426f4ul,                                                 // 1.11.0
         };
 
         constexpr static std::array visitor_names = {
@@ -290,6 +294,7 @@ class DateParser {
             0x849388ul,                                                 // 1.8.0
             0x86ccc0ul,                                                 // 1.9.0
             0x86ccd0ul,                                                 // 1.10.0
+	    0x86ccd0ul,                                                 // 1.11.0
         };
 
         static_assert(date_offsets.size() == static_cast<std::size_t>(Version::Total));
@@ -335,6 +340,7 @@ class WeatherSeedParser {
             0x1e24d4ul,                                                 // 1.8.0
             0x1e24d4ul,                                                 // 1.9.0
             0x1e24e4ul,                                                 // 1.10.0
+	    0x1e24e4ul,                                                 // 1.11.0
         };
 
         constexpr static std::uint32_t weather_seed_max = 2147483647;


### PR DESCRIPTION
Updated it with the same offsets used for v1.10.0.
Tested it and it seems to be working.