### PR TITLE
Update for 3.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 TOPDIR           ?=   $(CURDIR)
 
-VERSION           =   1.7.5
+VERSION           =   1.7.6
 COMMIT            =   $(shell git rev-parse --short HEAD)
 
 # -----------------------------------------------

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -43,7 +43,7 @@ enum class Version: std::size_t {
     V1100,
     V1110, V1111,
     V200, V201, V202, V203, V204, V205, V206, V207, V208,
-    V300,
+    V300,V301,
     Unknown,
     Total = Unknown,
 };
@@ -140,6 +140,7 @@ class VersionParser {
             VersionInfo{ 0x80009, 0x80085, 2, 0, 2, 29 }, // 2.0.7
             VersionInfo{ 0x80009, 0x80085, 2, 0, 2, 30 }, // 2.0.8
             VersionInfo{ 0xA0002, 0xA0028, 2, 0, 2, 31 }, // 3.0.0
+            VersionInfo{ 0xA0002, 0xA0028, 2, 0, 2, 32 }, // 3.0.1
         };
 
         static_assert(versions.size() == static_cast<std::size_t>(Version::Total));
@@ -185,7 +186,7 @@ class TurnipParser {
             0x43ec7cul,                                                                                                 // 1.10.0
             0x43ec7cul, 0x43ec7cul,                                                                                     // 1.11.x
             0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, // 2.0.x
-            0x490770ul,                                                                                                 // 3.0.0
+            0x490770ul, 0x490770ul,                                                                                     // 3.0.x
         };
 
         constexpr static std::array turnip_patterns = {
@@ -238,7 +239,7 @@ class VisitorParser {
             0x4426f4ul,                                                                                                 // 1.10.0
             0x4426f4ul, 0x4426f4ul,                                                                                     // 1.11.x
             0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, // 2.0.x
-            0x494624ul,                                                                                                 // 3.0.0
+            0x494624ul, 0x494624ul,                                                                                     // 3.0.x
         };
 
         constexpr static std::array visitor_names = {
@@ -313,7 +314,7 @@ class DateParser {
             0x86ccd0ul,                                                                                                 // 1.10.0
             0x86ccd0ul, 0x86ccd0ul,                                                                                     // 1.11.x
             0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, // 2.0.x
-            0x97d670ul,                                                                                                 // 3.0.0
+            0x97d670ul, 0x97d670ul,                                                                                     // 3.0.x
         };
 
         static_assert(date_offsets.size() == static_cast<std::size_t>(Version::Total));
@@ -361,7 +362,7 @@ class WeatherSeedParser {
             0x1e24e4ul,                                                                                                 // 1.10.0
             0x1e24e4ul, 0x1e24e4ul,                                                                                     // 1.11.x
             0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, // 2.0.x
-            0x1e3714ul,                                                                                                 // 3.0.0
+            0x1e3714ul, 0x1e3714ul,                                                                                     // 3.0.x
         };
 
         constexpr static std::uint32_t weather_seed_max = 2147483647;


### PR DESCRIPTION
This PR updates the tool to work with game version 3.0.1 by adding the new version enum and extending the existing 3.0.x parser mappings accordingly. 

## What changed
- Bumped tool version to 1.7.6.
- Added `V301` enum variant and registered 3.0.1 with the new save revision. 
- Updated per-version arrays for `TurnipParser`, `VisitorParser`, `DateParser`, and `WeatherSeedParser` to include an additional 3.0.x entry so 3.0.1 is recognized and handled (seems like 3.0.1 reuses the same offsets as 3.0.0).

Validated on a real save from my console.

Once again, thank you for this amazing tool! Looking forward to your feedback on these changes! 

Closes #69 