### PR TITLE
Update for 3.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 TOPDIR           ?=   $(CURDIR)
 
-VERSION           =   1.7.6
+VERSION           =   1.7.7
 COMMIT            =   $(shell git rev-parse --short HEAD)
 
 # -----------------------------------------------

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -43,7 +43,7 @@ enum class Version: std::size_t {
     V1100,
     V1110, V1111,
     V200, V201, V202, V203, V204, V205, V206, V207, V208,
-    V300,V301,
+    V300, V301, V302, 
     Unknown,
     Total = Unknown,
 };
@@ -141,6 +141,7 @@ class VersionParser {
             VersionInfo{ 0x80009, 0x80085, 2, 0, 2, 30 }, // 2.0.8
             VersionInfo{ 0xA0002, 0xA0028, 2, 0, 2, 31 }, // 3.0.0
             VersionInfo{ 0xA0002, 0xA0028, 2, 0, 2, 32 }, // 3.0.1
+            VersionInfo{ 0xA0002, 0xA0028, 2, 0, 2, 33 }, // 3.0.2
         };
 
         static_assert(versions.size() == static_cast<std::size_t>(Version::Total));
@@ -186,7 +187,7 @@ class TurnipParser {
             0x43ec7cul,                                                                                                 // 1.10.0
             0x43ec7cul, 0x43ec7cul,                                                                                     // 1.11.x
             0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, 0x45e35cul, // 2.0.x
-            0x490770ul, 0x490770ul,                                                                                     // 3.0.x
+            0x490770ul, 0x490770ul, 0x490770ul,                                                                         // 3.0.x
         };
 
         constexpr static std::array turnip_patterns = {
@@ -239,7 +240,7 @@ class VisitorParser {
             0x4426f4ul,                                                                                                 // 1.10.0
             0x4426f4ul, 0x4426f4ul,                                                                                     // 1.11.x
             0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, 0x462158ul, // 2.0.x
-            0x494624ul, 0x494624ul,                                                                                     // 3.0.x
+            0x494624ul, 0x494624ul, 0x494624ul,                                                                         // 3.0.x
         };
 
         constexpr static std::array visitor_names = {
@@ -314,7 +315,7 @@ class DateParser {
             0x86ccd0ul,                                                                                                 // 1.10.0
             0x86ccd0ul, 0x86ccd0ul,                                                                                     // 1.11.x
             0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, 0x8be540ul, // 2.0.x
-            0x97d670ul, 0x97d670ul,                                                                                     // 3.0.x
+            0x97d670ul, 0x97d670ul, 0x97d670ul,                                                                         // 3.0.x
         };
 
         static_assert(date_offsets.size() == static_cast<std::size_t>(Version::Total));
@@ -362,7 +363,7 @@ class WeatherSeedParser {
             0x1e24e4ul,                                                                                                 // 1.10.0
             0x1e24e4ul, 0x1e24e4ul,                                                                                     // 1.11.x
             0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, 0x1e3714ul, // 2.0.x
-            0x1e3714ul, 0x1e3714ul,                                                                                     // 3.0.x
+            0x1e3714ul, 0x1e3714ul, 0x1e3714ul,                                                                         // 3.0.x
         };
 
         constexpr static std::uint32_t weather_seed_max = 2147483647;


### PR DESCRIPTION
This PR updates the tool to work with game version 3.0.2 by adding the new version enum and extending the existing 3.0.x parser mappings accordingly.

## What changed
- Bumped tool version to 1.7.7.
- Added `V302` enum variant and registered 3.0.2 with the new save revision.
- Updated per-version arrays for `TurnipParser`, `VisitorParser`, `DateParser`, and `WeatherSeedParser` to include an additional 3.0.x entry so 3.0.2 is recognized and handled (3.0.2 reuses the same offsets as 3.0.1).

Validated on a real save from my console.

Huge thanks as always, looking forward to hearing your thoughts!

Closes #73 